### PR TITLE
added a method to pass relationships through the query parameters usi…

### DIFF
--- a/app/sdk/data/DataSetItem.java
+++ b/app/sdk/data/DataSetItem.java
@@ -920,7 +920,7 @@ public class DataSetItem {
         json.put("clientKey", clientKey);
         json.put("recordType", getItemType().stringValue);
         json.put("status", status.stringValue);
-        json.put("lazyLoadedRelationships", lazyLoadedRelationships != null ? lazyLoadedRelationships.toString() : null);
+        json.put("lazyLoadedRelationships", lazyLoadedRelationships != null ? JsonUtils.toJson(lazyLoadedRelationships) : null);
 
         ArrayNode attributes = json.putArray("attributes");
         int firstNullIndex = -1;

--- a/app/sdk/data/DataSetItem.java
+++ b/app/sdk/data/DataSetItem.java
@@ -27,6 +27,7 @@ public class DataSetItem {
     private CRUDStatus crudStatus = CRUDStatus.Read;
     private Status status = Status.None;
     Collection<ServiceConfigurationAttribute> configurationAttributes;
+    Collection<Integer> lazyLoadedRelationships;
 
     @JsonIgnore
     protected HashMap<Integer, ServiceConfigurationAttribute> configurationMap;
@@ -49,6 +50,17 @@ public class DataSetItem {
     public ServiceConfigurationAttribute getAttributeWithIndex(int index) {
         if (configurationMap == null ) return null;
         return configurationMap.get(index);
+    }
+
+    public void useLazyLoad(int attributeIndex) {
+        ServiceConfigurationAttribute attribute = getAttributeWithIndex(attributeIndex);
+        if ( attribute == null || !attribute.attributeType.equals(AttributeType.Relation) ) {
+            throw new RuntimeException("Attempting to use lazy loading on an attribute that isn't a relationship");
+        }
+        if ( lazyLoadedRelationships == null ) {
+            lazyLoadedRelationships = new ArrayList<>();
+        }
+        lazyLoadedRelationships.add(attributeIndex);
     }
 
     public enum Type {
@@ -908,6 +920,7 @@ public class DataSetItem {
         json.put("clientKey", clientKey);
         json.put("recordType", getItemType().stringValue);
         json.put("status", status.stringValue);
+        json.put("lazyLoadedRelationships", lazyLoadedRelationships != null ? lazyLoadedRelationships.toString() : null);
 
         ArrayNode attributes = json.putArray("attributes");
         int firstNullIndex = -1;

--- a/app/sdk/utils/Parameters.java
+++ b/app/sdk/utils/Parameters.java
@@ -2,16 +2,15 @@ package sdk.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import play.libs.Json;
 import sdk.models.DateRange;
 import sdk.models.Location;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Created by alexis on 5/3/16.
@@ -187,5 +186,14 @@ public class Parameters {
         }
 
         return offset;
+    }
+
+    public List<Integer> getPrefetchRelationships() {
+        List<Integer> prefetchRelationships = new ArrayList<>();
+        String relationshipString = parameters.get("relationships");
+        if ( !StringUtils.isEmpty(relationshipString) ) {
+            prefetchRelationships = Arrays.stream(relationshipString.split(",")).map(String::trim).map(Integer::parseInt).collect(Collectors.toList());
+        }
+        return prefetchRelationships;
     }
 }


### PR DESCRIPTION
…ng ‘relationships’ as the key for a csv string of attribute indices that should be automatically fetched

added methods on dataset item to indicate which relationships have been lazily loaded