### PR TITLE
A fix for primary keys that aren't attributes

### DIFF
--- a/app/sdk/converter/ObjectConverter.java
+++ b/app/sdk/converter/ObjectConverter.java
@@ -179,6 +179,7 @@ public class ObjectConverter extends ConfigurationManager {
 
         if (primaryKey && !attributeProxy.isAttribute()) {
             record.setPrimaryKey(attributeProxy.getValue(source).toString());
+            return;
         }
 
         int index = attributeProxy.getIndex();


### PR DESCRIPTION
There was an issue with object that had primary keys that weren't object having the wrong data types. 