### PR TITLE
Using negative one for empty index instead of a null value

### DIFF
--- a/app/sdk/converter/AttributeProxy.java
+++ b/app/sdk/converter/AttributeProxy.java
@@ -63,7 +63,7 @@ public class AttributeProxy {
         }
         return !Null(attribute) ?
                 attribute.index() :
-                null;
+                -1;
     }
 
     public boolean isAttribute() {


### PR DESCRIPTION
The annotation processor was throwing a null pointer exception when trying to call toString() on the primary key value. 