### PR TITLE
Json parsing error and item value

### DIFF
--- a/app/sdk/converter/ObjectConverter.java
+++ b/app/sdk/converter/ObjectConverter.java
@@ -166,20 +166,17 @@ public class ObjectConverter extends ConfigurationManager {
                                           T source) throws UnsupportedAttributeException,
                                                            IllegalAccessException,
                                                            InvocationTargetException {
-        boolean primaryKey = false;
-        boolean value = false;
-        boolean parentValue = false;
 
-        boolean excludeFromListItem = attributeProxy.excludeFromList();
         if (record.isListItem() && attributeProxy.excludeFromList()) return;
 
-        primaryKey = attributeProxy.isPrimaryKey();
-        value = attributeProxy.isPrimaryValue();
-        parentValue = attributeProxy.isParentValue();
+        boolean primaryKey = attributeProxy.isPrimaryKey();
+        boolean value = attributeProxy.isPrimaryValue();
+        boolean parentValue = attributeProxy.isParentValue();
 
-        if (primaryKey && !attributeProxy.isAttribute()) {
+        if(primaryKey) {
             record.setPrimaryKey(attributeProxy.getValue(source).toString());
-            return;
+            if(record.getValue() == null) record.setValue(attributeProxy.getValue(source).toString());
+            if(!attributeProxy.isAttribute()) return;
         }
 
         int index = attributeProxy.getIndex();

--- a/app/sdk/converter/TypeManager.java
+++ b/app/sdk/converter/TypeManager.java
@@ -228,12 +228,12 @@ public class TypeManager {
         Map<Integer, Boolean> findDuplicateIndex = new HashMap<>();
         boolean primaryKeyIsSet = false;
         for(AttributeProxy proxy : attributeProxies) {
-            if(findDuplicateIndex.putIfAbsent(proxy.getIndex(), true) != null) {
-                throw new RuntimeException("field named '" + proxy.getName() + "' shares an index with another field in the same model");
-            }
             if(proxy.isPrimaryKey()) {
                 if(primaryKeyIsSet) throw new RuntimeException("field named '" + proxy.getName() + "' redefines a primary key");
                 else primaryKeyIsSet = true;
+            }
+            if(proxy.isAttribute() && findDuplicateIndex.putIfAbsent(proxy.getIndex(), true) != null) {
+                throw new RuntimeException("field named '" + proxy.getName() + "' shares an index with another field in the same model");
             }
         }
         return attributeProxies;

--- a/app/sdk/data/DataSetItem.java
+++ b/app/sdk/data/DataSetItem.java
@@ -1543,7 +1543,7 @@ public class DataSetItem implements Record {
                                             });
                                             break;
                                         case Boolean:
-                                            JsonUtils.parseOptional(textValue).ifPresent(listItemNode -> {
+                                            JsonUtils.parseOptionalBoolean(textValue).ifPresent(listItemNode -> {
                                                 Boolean aBoolean = JsonUtils.fromJson(listItemNode, Boolean.class);
                                                 listItem.setAttributeForIndex(aBoolean, attr.getAttributeIndex());
                                             });

--- a/app/sdk/utils/JsonUtils.java
+++ b/app/sdk/utils/JsonUtils.java
@@ -32,6 +32,15 @@ public class JsonUtils {
         return Optional.empty();
     }
 
+    public static Optional<JsonNode> parseOptionalBoolean(String src) {
+        if( src == null ) return Optional.empty();
+        try {
+            src = (src.equals("Y")) ? "true" : "false";
+            return Optional.of(Json.parse(src));
+        } catch(Exception ignored) {}
+        return Optional.empty();
+    }
+
     private static ObjectMapper objectMapper;
 
     public static ObjectMapper getObjectMapper() {

--- a/test/ConverterTest.java
+++ b/test/ConverterTest.java
@@ -98,7 +98,7 @@ public class ConverterTest {
         dataSetItem.setDateTime(sampleObject.testJodaTimeDate, 9);
         dataSetItem.setListItem(getSampleListItem(), 10);
         DataSetItem singleRelationShip = dataSetItem.addNewDataSetItemForAttributeIndex(11);
-        copyDataToSingleListItem(singleRelationShip);
+        copyDataToSingleRelationship(singleRelationShip);
         List<SampleRelationship> relationshipList = getSampleRelationshipList();
         for (SampleRelationship sampleRelationship : relationshipList) {
             DataSetItem tempDataSetItem = dataSetItem.addNewDataSetItemForAttributeIndex(12);
@@ -151,7 +151,7 @@ public class ConverterTest {
     }
 
 
-    private void copyDataToSingleListItem(DataSetItem dataSetItem) {
+    private void copyDataToSingleRelationship(DataSetItem dataSetItem) {
         dataSetItem.setString("1234", 0);
         dataSetItem.setInt(1, 1);
         dataSetItem.setInt(1, 2);
@@ -178,6 +178,9 @@ public class ConverterTest {
         listItem.setDateTime(new DateTime(100), 7);
         listItem.setDateTime(new DateTime(100), 8);
         listItem.setDateTime(new DateTime(100), 9);
+        Image image = new Image();
+        image.imageURL = "myurl.com/attachmentImage.jpg";
+        listItem.setImage(image, 10);
         return listItem;
     }
 

--- a/test/ListItemAttributeTest.java
+++ b/test/ListItemAttributeTest.java
@@ -145,6 +145,4 @@ public class ListItemAttributeTest {
             this.parentId = parentId;
         }
     }
-
-
 }

--- a/test/SampleObject.java
+++ b/test/SampleObject.java
@@ -112,8 +112,8 @@ public class SampleObject {
         attributes.add(new ServiceConfigurationAttribute.Builder(8).name("Test Joda Time Date").canCreate().canSearch().canUpdate().asDateTime().build());
         attributes.add(new ServiceConfigurationAttribute.Builder(9).name("Test Sql Date").canCreate().canSearch().canUpdate().asDateTime().build());
         attributes.add(new ServiceConfigurationAttribute.Builder(10).name("Sample List Item").canCreate().canSearch().canUpdate().asListItem(SampleListItem.getListServiceConfigurationAttributes()).build());
-        attributes.add(new ServiceConfigurationAttribute.Builder(11).name("Sample List Item Single Relationship").canCreate().canSearch().canUpdate().asSingleRelationship(new RelatedServiceConfiguration("sampleListItemSingleRelationship", SampleListItem.getServiceConfigurationAttributes())).build());
-        attributes.add(new ServiceConfigurationAttribute.Builder(12).name("Sample List Item Relationship").canCreate().canSearch().canUpdate().asRelationship(new RelatedServiceConfiguration("sampleListItemSingleRelationship", SampleListItem.getServiceConfigurationAttributes())).build());
+        attributes.add(new ServiceConfigurationAttribute.Builder(11).name("Sample List Item Single Relationship").canCreate().canSearch().canUpdate().asSingleRelationship(new RelatedServiceConfiguration("sampleListItemSingleRelationship", SampleRelationship.getServiceConfigurationAttributes())).build());
+        attributes.add(new ServiceConfigurationAttribute.Builder(12).name("Sample List Item Relationship").canCreate().canSearch().canUpdate().asRelationship(new RelatedServiceConfiguration("sampleListItemSingleRelationship", SampleRelationship.getServiceConfigurationAttributes())).build());
         attributes.add(new ServiceConfigurationAttribute.Builder(17).name("Color").asColor().canCreate().canUpdate().canSearch().build());
         attributes.add(new ServiceConfigurationAttribute.Builder(18).name("Sdk Location").asLocation().canUpdate().canCreate().canSearch().build());
         attributes.add(new ServiceConfigurationAttribute.Builder(19).name("Custom Location").asLocation().canUpdate().canCreate().canSearch().build());

--- a/test/SampleRelationship.java
+++ b/test/SampleRelationship.java
@@ -1,8 +1,11 @@
 import org.joda.time.DateTime;
 import sdk.annotations.Attribute;
 import sdk.data.DataSetItem;
+import sdk.data.ServiceConfigurationAttribute;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Created by Orozco on 7/25/17.
@@ -58,5 +61,19 @@ public class SampleRelationship {
 //        dataSetItem.setListItem(sampleListItem.toListItem(), 10);
     }
 
-
+    public static List<ServiceConfigurationAttribute> getServiceConfigurationAttributes() {
+        List<ServiceConfigurationAttribute> attributes = new ArrayList<>();
+        attributes.add( new ServiceConfigurationAttribute.Builder(0).name("woNumber").build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(1).name("testInt").asInt().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(2).name("testIntObject").asInt().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(3).name("testFloat").asDouble().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(4).name("testFloatObject").asDouble().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(5).name("testDouble").asDouble().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(6).name("testDoubleObject").asDouble().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(7).name("testDate").asDateTime().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(8).name("testJodaTimeDate").asDateTime().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(9).name("testSqlDate").asDateTime().build());
+        attributes.add( new ServiceConfigurationAttribute.Builder(10).name("sample list item").asListItem(SampleListItem.getListServiceConfigurationAttributes()).build());
+        return attributes;
+    }
 }


### PR DESCRIPTION
Tests were using the SampleListItem configuration on a field for SampleRelationship.

Updated the annotation processor to set the primary key as default if not set.

Added new method in JsonUtils to parse a boolean field. Field was not being parsed correctly on a nested ListItem.