### PR TITLE
Query primary key issue

### DIFF
--- a/app/sdk/converter/ObjectConverter.java
+++ b/app/sdk/converter/ObjectConverter.java
@@ -99,8 +99,10 @@ public class ObjectConverter extends ConfigurationManager {
      * @param destination
      * @param <T>
      */
-    public static <T> ParserContext copyFromRecord(Record record, T destination) {
+    public static <T> ParserContext copyFromRecord(Record record, T destination,
+                                                   boolean isSearchForm) {
         ParserContext parserContext = getParserContext();
+        parserContext.setSearchForm(isSearchForm);
         mapMethodsFromSource(destination);
         if (destination == null) {
             throw new DestinationInvalidException();
@@ -110,11 +112,18 @@ public class ObjectConverter extends ConfigurationManager {
         }
         for (AttributeProxy proxy : getMethodAndFieldAnnotationsForClass(destination.getClass())) {
             try {
-                if (proxy.isPrimaryKey())
-                    proxy.setPrimaryKeyOrValue(destination, record.getPrimaryKey());
-                if (proxy.isPrimaryValue())
-                    proxy.setPrimaryKeyOrValue(destination, record.getValue());
+
                 copyToField(proxy, record, destination, parserContext);
+                //if the dataSetItem is coming from a search form the values in the primary key/value
+                // will always be null.
+                //If NOT coming from a search form we want the given primary key/value values to
+                //always over write what was copied in the object copy because primary key/value shoudl not be editable
+                if (!isSearchForm) {
+                    if (proxy.isPrimaryKey())
+                        proxy.setPrimaryKeyOrValue(destination, record.getPrimaryKey());
+                    if (proxy.isPrimaryValue())
+                        proxy.setPrimaryKeyOrValue(destination, record.getValue());
+                }
             } catch (UnsupportedAttributeException | IllegalAccessException | UnableToWriteException | InvocationTargetException e) {
                 e.printStackTrace();
             }
@@ -155,14 +164,16 @@ public class ObjectConverter extends ConfigurationManager {
      * @param <T>
      * @param loadRelationshipIndexes
      */
-    public static <T> void copyToRecord(Record record, T source, List<Integer> loadRelationshipIndexes) {
+    public static <T> void copyToRecord(Record record, T source,
+                                        List<Integer> loadRelationshipIndexes) {
         if (source == null) return;
         Set<Integer> relationshipsToLoad = new HashSet<>(loadRelationshipIndexes);
         mapMethodsFromSource(source);
         for (AttributeProxy attributeProxy : getMethodAndFieldAnnotationsForClass(
             source.getClass())) {
             try {
-                attributeProxy.setLoadRelationshipData(relationshipsToLoad.contains(attributeProxy.getIndex()));
+                attributeProxy.setLoadRelationshipData(
+                    relationshipsToLoad.contains(attributeProxy.getIndex()));
                 copyFromField(attributeProxy, record, source);
             } catch (UnsupportedAttributeException | IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
@@ -290,7 +301,7 @@ public class ObjectConverter extends ConfigurationManager {
                 break;
             case ListItem:
                 writeListItemData(proxy, destination, dataSetItem,
-                                  attributeMeta.getAttributeIndex());
+                                  attributeMeta.getAttributeIndex(), parserContext);
                 break;
             case SingleRelationship:
                 writeSingleRelationshipData(proxy, destination, dataSetItem,
@@ -614,14 +625,16 @@ public class ObjectConverter extends ConfigurationManager {
      * @throws InvocationTargetException
      */
     private static <T> void writeListItemData(AttributeProxy proxy, T destination,
-                                              Record dataSetItem, Integer index) throws
-                                                                                 UnableToWriteException,
-                                                                                 InvocationTargetException {
+                                              Record dataSetItem, Integer index,
+                                              ParserContext parserContext) throws
+                                                                           UnableToWriteException,
+                                                                           InvocationTargetException {
         ListItem listItem = dataSetItem.getListItem(index);
         if (listItem == null) return;
         Type fieldType = proxy.getType();
         Class classValue = null;
-        copyFromRecordRecursive(proxy, fieldType, classValue, listItem, destination, index);
+        copyFromRecordRecursive(proxy, fieldType, classValue, listItem, destination, index,
+                                parserContext.isSearchForm());
     }
 
     /**
@@ -643,7 +656,8 @@ public class ObjectConverter extends ConfigurationManager {
         if (newDataSetItem == null) return;
         Type fieldType = proxy.getType();
         Class classValue = null;
-        copyFromRecordRecursive(proxy, fieldType, classValue, newDataSetItem, destination, index);
+        copyFromRecordRecursive(proxy, fieldType, classValue, newDataSetItem, destination, index,
+                                parserContext.isSearchForm());
     }
 
     private static <T> void writeImageData(AttributeProxy proxy, T destination,
@@ -661,14 +675,14 @@ public class ObjectConverter extends ConfigurationManager {
 
     private static <T> void copyFromRecordRecursive(AttributeProxy proxy, Type fieldType,
                                                     Class classValue, Record record, T destination,
-                                                    Integer index)
+                                                    Integer index, boolean isSearchForm)
         throws InvocationTargetException, UnableToWriteException {
         try {
-            if(!findTypeOnSimpleName(fieldType.getTypeName()).isOptional())
+            if (!findTypeOnSimpleName(fieldType.getTypeName()).isOptional())
                 classValue = primitiveToWrapper(fieldType.getTypeName());
             else classValue = Class.forName(fieldType.getTypeName());
             Object object = classValue.newInstance();
-            copyFromRecord(record, object);
+            copyFromRecord(record, object, isSearchForm);
             useSetterIfExists(proxy, destination, object);
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ie) {
             throw new UnableToWriteException(classValue.getName(), index,
@@ -699,7 +713,7 @@ public class ObjectConverter extends ConfigurationManager {
             ArrayList<Object> tempList = new ArrayList<>();
             for (DataSetItem dataSetItem1 : dataSetItems) {
                 Object object = classValue.newInstance();
-                copyFromRecord(dataSetItem1, object);
+                copyFromRecord(dataSetItem1, object, parserContext.isSearchForm());
                 tempList.add(object);
             }
             useSetterIfExists(proxy, destination, tempList);
@@ -828,7 +842,7 @@ public class ObjectConverter extends ConfigurationManager {
             InputStream byteArrayInputStream =
                 new ByteArrayInputStream(attachmentItem.getAttachmentBytes());
             object.setInputStream(byteArrayInputStream);
-        } else if(attachmentItem.getCRUDStatus() == DataSetItem.CRUDStatus.Create) {
+        } else if (attachmentItem.getCRUDStatus() == DataSetItem.CRUDStatus.Create) {
             throw new RuntimeException("Attachment uploaded without any data.");
         }
     }
@@ -1253,8 +1267,9 @@ public class ObjectConverter extends ConfigurationManager {
                                                                              IllegalAccessException,
                                                                              InvocationTargetException {
         List<Object> relationship;
-        if(attributeProxy.useLazyLoad()) dataSetItem.useLazyLoad(index);
-        if(attributeProxy.loadRelationshipData() || attributeProxy.getRelationshipAnnotation().eager()) {
+        if (attributeProxy.useLazyLoad()) dataSetItem.useLazyLoad(index);
+        if (attributeProxy.loadRelationshipData() ||
+            attributeProxy.getRelationshipAnnotation().eager()) {
             if (useGetterAndSetter) {
                 relationship = (List<Object>) useGetterIfExists(attributeProxy, object);
             } else relationship = (List<Object>) attributeProxy.getValue(object);

--- a/app/sdk/converter/ObjectConverter.java
+++ b/app/sdk/converter/ObjectConverter.java
@@ -110,11 +110,11 @@ public class ObjectConverter extends ConfigurationManager {
         }
         for (AttributeProxy proxy : getMethodAndFieldAnnotationsForClass(destination.getClass())) {
             try {
-                copyToField(proxy, record, destination, parserContext);
                 if (proxy.isPrimaryKey())
                     proxy.setPrimaryKeyOrValue(destination, record.getPrimaryKey());
                 if (proxy.isPrimaryValue())
                     proxy.setPrimaryKeyOrValue(destination, record.getValue());
+                copyToField(proxy, record, destination, parserContext);
             } catch (UnsupportedAttributeException | IllegalAccessException | UnableToWriteException | InvocationTargetException e) {
                 e.printStackTrace();
             }

--- a/app/sdk/converter/ParserContext.java
+++ b/app/sdk/converter/ParserContext.java
@@ -18,6 +18,7 @@ public class ParserContext {
     private static final String APP_ID = "APP-ID";
     private Map<Integer, SDKDateRange> dateTimeRangeIntegerIndexMap;
     private Map<String, SDKDateRange> dateTimeRangeStringIndexMap;
+    private boolean isSearchForm;
 
     public CRUDStatus getState(Object object) {
         CRUDStatus status = getCrudStatusMap().get(object);
@@ -145,5 +146,13 @@ public class ParserContext {
 
     public void setDateTimeRangeStringIndexMap(Map<String, SDKDateRange> dateTimeRangeStringIndexMap) {
         this.dateTimeRangeStringIndexMap = dateTimeRangeStringIndexMap;
+    }
+
+    public boolean isSearchForm() {
+        return isSearchForm;
+    }
+
+    public void setSearchForm(boolean searchForm) {
+        isSearchForm = searchForm;
     }
 }

--- a/app/sdk/datasources/base/ConversionDataSource.java
+++ b/app/sdk/datasources/base/ConversionDataSource.java
@@ -15,13 +15,13 @@ import java.util.ArrayList;
 public abstract class ConversionDataSource<S, D> implements ConversionDataSourceBase {
 
     public D convertRecord(DataSetItem dataSetItem, S object) {
-        ObjectConverter.copyFromRecord(dataSetItem, object, true);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return convert(object);
     }
 
     public D convertRecord(DataSetItem previousDataSetItem, DataSetItem dataSetItem, S previousObject, S object) {
-        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject, true);
-        ObjectConverter.copyFromRecord(dataSetItem, object, true);
+        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject, false);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return convert(previousObject, object);
     }
 

--- a/app/sdk/datasources/base/ConversionDataSource.java
+++ b/app/sdk/datasources/base/ConversionDataSource.java
@@ -15,13 +15,13 @@ import java.util.ArrayList;
 public abstract class ConversionDataSource<S, D> implements ConversionDataSourceBase {
 
     public D convertRecord(DataSetItem dataSetItem, S object) {
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(dataSetItem, object, true);
         return convert(object);
     }
 
     public D convertRecord(DataSetItem previousDataSetItem, DataSetItem dataSetItem, S previousObject, S object) {
-        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject);
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject, true);
+        ObjectConverter.copyFromRecord(dataSetItem, object, true);
         return convert(previousObject, object);
     }
 

--- a/app/sdk/datasources/base/TypedDataSource.java
+++ b/app/sdk/datasources/base/TypedDataSource.java
@@ -38,7 +38,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public DataSet queryDataSet(DataSetItem queryDataItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(queryDataItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(queryDataItem, object, true);
         Collection<? extends Object> objects = query(object, authenticationInfo, params, parserContext);
         return ObjectConverter.getDataSetFromCollection(objects, getAttributes(), params.getPrefetchRelationships());
     }
@@ -46,7 +46,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public RecordActionResponse createRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         parserContext.setUserId(authenticationInfo.getUserID());
         parserContext.setAppId(authenticationInfo.getCustomAuthenticationParameter(Constants.APP_ID_HEADER));
         return create(object, authenticationInfo, params, parserContext);
@@ -56,7 +56,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public RecordActionResponse validateRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         parserContext.setUserId(authenticationInfo.getUserID());
         parserContext.setAppId(authenticationInfo.getCustomAuthenticationParameter(Constants.APP_ID_HEADER));
         return validate(object, authenticationInfo, params, parserContext);
@@ -65,7 +65,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public RecordActionResponse updateRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         parserContext.setUserId(authenticationInfo.getUserID());
         parserContext.setAppId(authenticationInfo.getCustomAuthenticationParameter(Constants.APP_ID_HEADER));
         return update(object, authenticationInfo, params, parserContext);

--- a/app/sdk/datasources/future/ConversionDataSource.java
+++ b/app/sdk/datasources/future/ConversionDataSource.java
@@ -16,13 +16,13 @@ import java.util.concurrent.CompletableFuture;
 public abstract class ConversionDataSource<S, D> implements ConversionDataSourceBase {
 
     public CompletableFuture<D> convertRecord(DataSetItem dataSetItem, S object) {
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return convert(object);
     }
 
     public CompletableFuture<D> convertRecord(DataSetItem previousDataSetItem, DataSetItem dataSetItem, S previousObject, S object) {
-        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject);
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject, false);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return convert(previousObject, object);
     }
 

--- a/app/sdk/datasources/future/TypedDataSource.java
+++ b/app/sdk/datasources/future/TypedDataSource.java
@@ -37,7 +37,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public CompletableFuture<DataSet> queryDataSet(DataSetItem queryDataItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ObjectConverter.copyFromRecord(queryDataItem, object);
+        ObjectConverter.copyFromRecord(queryDataItem, object, false);
         CompletableFuture<Collection<T>> objects = query(object, authenticationInfo, params);
         return objects.thenApply(list -> ObjectConverter.getDataSetFromCollection(list, getAttributes()));
     }
@@ -45,14 +45,14 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public CompletableFuture<RecordActionResponse> createRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return create(object, authenticationInfo, params);
     }
 
     @Override
     public CompletableFuture<RecordActionResponse> updateRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return update(object, authenticationInfo, params, parserContext);
     }
 
@@ -60,7 +60,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public CompletableFuture<RecordActionResponse> validateRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return validate(object, authenticationInfo, params, parserContext);
     }
 

--- a/app/sdk/datasources/rx/ConversionDataSource.java
+++ b/app/sdk/datasources/rx/ConversionDataSource.java
@@ -18,13 +18,13 @@ import java.util.Collection;
 public abstract class ConversionDataSource<S, D> implements ConversionDataSourceBase {
 
     public Observable<D> convertRecord(DataSetItem dataSetItem, S object) {
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return convert(object);
     }
 
     public Observable<D> convertRecord(DataSetItem previousDataSetItem, DataSetItem dataSetItem, S previousObject, S object) {
-        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject);
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(previousDataSetItem, previousObject, false);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return convert(previousObject, object);
     }
 

--- a/app/sdk/datasources/rx/TypedDataSource.java
+++ b/app/sdk/datasources/rx/TypedDataSource.java
@@ -42,7 +42,7 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public Observable<DataSet> queryDataSet(DataSetItem queryDataItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ObjectConverter.copyFromRecord(queryDataItem, object);
+        ObjectConverter.copyFromRecord(queryDataItem, object, true);
         Observable<Collection<T>> objects = query(object, authenticationInfo, params);
         return objects.map(list -> ObjectConverter.getDataSetFromCollection(list, getAttributes()));
     }
@@ -50,21 +50,21 @@ public abstract class TypedDataSource<T extends Object> implements DataSource {
     @Override
     public Observable<RecordActionResponse> createRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ObjectConverter.copyFromRecord(dataSetItem, object);
+        ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return create(object, authenticationInfo, params);
     }
 
     @Override
     public Observable<RecordActionResponse> updateRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return update(object, authenticationInfo, params, parserContext);
     }
 
     @Override
     public Observable<RecordActionResponse> validateRecord(DataSetItem dataSetItem, AuthenticationInfo authenticationInfo, Parameters params) {
         T object = getNewInstance();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, object, false);
         return validate(object, authenticationInfo, params, parserContext);
     }
 

--- a/test/ConverterTest.java
+++ b/test/ConverterTest.java
@@ -222,12 +222,12 @@ public class ConverterTest {
         SampleLazyLoadObj finalObj = new SampleLazyLoadObj();
         DataSetItem item = new DataSetItem(ObjectConverter.generateConfigurationAttributes(SampleLazyLoadObj.class));
         ObjectConverter.copyToRecord(item, obj);
-        ObjectConverter.copyFromRecord(item, finalObj);
+        ObjectConverter.copyFromRecord(item, finalObj, false);
         assert(finalObj.objList == null);
 
         List<Integer> loadProps = Arrays.asList(0, 1);
         ObjectConverter.copyToRecord(item, obj, loadProps);
-        ObjectConverter.copyFromRecord(item, finalObj);
+        ObjectConverter.copyFromRecord(item, finalObj, false);
         assert(finalObj.objList != null);
     }
 
@@ -238,7 +238,7 @@ public class ConverterTest {
         try {
             ObjectConverter.copyToRecord(item, obj);
             DataSetItem newItem = new DataSetItem(ObjectConverter.generateConfigurationAttributes(SamplePrimitivesObject.class));
-            ObjectConverter.copyFromRecord(newItem, obj);
+            ObjectConverter.copyFromRecord(newItem, obj, false);
             assert(obj.equivalent(item, obj));
             assert(obj.equivalent(newItem, new SamplePrimitivesObject()));
         } catch(Exception e) {
@@ -276,7 +276,7 @@ public class ConverterTest {
         ObjectConverter.copyToRecord(item, obj);
         assert(item.getPrimaryKey().equals(obj.getPk()));
         item.setPrimaryKey("different key");
-        ObjectConverter.copyFromRecord(item, obj);
+        ObjectConverter.copyFromRecord(item, obj, false);
         assert(obj.getPk().equals("different key"));
     }
 
@@ -288,7 +288,7 @@ public class ConverterTest {
         Image image = new Image();
         image.imageURL = "testUrl.com";
         record.setImage(image, 10);
-        ObjectConverter.copyFromRecord(record, object);
+        ObjectConverter.copyFromRecord(record, object, false);
         assert(record.getImage(10).imageURL.equals(object.image.imageURL));
     }
 
@@ -309,7 +309,7 @@ public class ConverterTest {
         attrs.setStringForAttributeIndex("first", 0);
         attrs.setStringForAttributeIndex("second", 1);
         attrs.setStringForAttributeIndex("third", 2);
-        ObjectConverter.copyFromRecord(attrs, obj);
+        ObjectConverter.copyFromRecord(attrs, obj, false);
         assert(attrs.getStringAttributeAtIndex(0).equals(obj.first));
         assert(attrs.getStringAttributeAtIndex(1).equals(obj.second));
         assert(attrs.getStringAttributeAtIndex(2).equals(obj.third));
@@ -369,7 +369,7 @@ public class ConverterTest {
         DataSetItem dataSetItem = new DataSetItem(sampleConf.getAttributes());
         DataSetItem testDataSetItem = new DataSetItem(sampleConf.getAttributes());
         dataSetItem = getHydratedDataSetItemFromSampleObject(dataSetItem, getSampleObject());
-        ObjectConverter.copyFromRecord(dataSetItem, sampleObject);
+        ObjectConverter.copyFromRecord(dataSetItem, sampleObject, false);
         ObjectConverter.copyToRecord(testDataSetItem, sampleObject);
         Assert.assertTrue(dataSetItem.equals(testDataSetItem));
     }
@@ -684,7 +684,7 @@ public class ConverterTest {
         DataSetItem dataSetItem = new DataSetItem(ObjectConverter.generateConfigurationAttributes(SampleObject.class));
         ObjectConverter.copyToRecord(dataSetItem, sampleObject);
         SampleObject testSampleObject = new SampleObject();
-        ObjectConverter.copyFromRecord(dataSetItem, testSampleObject);
+        ObjectConverter.copyFromRecord(dataSetItem, testSampleObject, false);
     }
 
 
@@ -737,7 +737,7 @@ public class ConverterTest {
     public void testExcludeFromListCopyFromRecord() {
         ExcludeFromList excludeFromList = new ExcludeFromList();
         DataSetItem testDataSetItem = ExcludeFromList.getTestDataSetItem();
-        ObjectConverter.copyFromRecord(testDataSetItem, excludeFromList);
+        ObjectConverter.copyFromRecord(testDataSetItem, excludeFromList, false);
         DataSetItem dataSetItem = new DataSetItem(ObjectConverter.generateConfigurationAttributes(ExcludeFromList.class));
         ObjectConverter.copyToRecord(dataSetItem, excludeFromList);
         Assert.assertTrue(dataSetItem.equals(testDataSetItem));

--- a/test/DateRangeTest.java
+++ b/test/DateRangeTest.java
@@ -48,7 +48,7 @@ public class DateRangeTest {
         dateRange.setTo(new DateTime());
         dataSetItem.setDateTimeRangeForAttributeIndex(dateRange, 0);
         DateRangeTestClass dateRangeTestClass = new DateRangeTestClass();
-        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, dateRangeTestClass);
+        ParserContext parserContext = ObjectConverter.copyFromRecord(dataSetItem, dateRangeTestClass, false);
         Assert.assertTrue((!parserContext.getDateTimeRangeForField(0).isEmpty()));
         Assert.assertTrue((parserContext.getDateTimeRangeForField(0).getFrom() != null));
         Assert.assertTrue((parserContext.getDateTimeRangeForField(0).getTo() != null));
@@ -79,7 +79,7 @@ public class DateRangeTest {
         DataSetItem dataSetitem = new DataSetItem(serviceConfiguration);
         dataSetitem.updateFromJSON(dataSetItemObject, new HashMap<>(), true);
         TestDateRangeObject testDateRangeObject = new TestDateRangeObject();
-        ParserContext context = ObjectConverter.copyFromRecord(dataSetitem, testDateRangeObject);
+        ParserContext context = ObjectConverter.copyFromRecord(dataSetitem, testDateRangeObject, false);
         DateTimeRange dateTime = context.getDateTimeRangeForField("dateTime");
         Assert.assertTrue(dateTime != null);
         Assert.assertTrue(dateTime.getFrom() != null);
@@ -108,7 +108,7 @@ public class DateRangeTest {
         DataSetItem dataSetitem = new DataSetItem(serviceConfiguration);
         dataSetitem.updateFromJSON(dataSetItemObject, new HashMap<>(), false);
         TestDateRangeObject testDateRangeObject = new TestDateRangeObject();
-        ParserContext context = ObjectConverter.copyFromRecord(dataSetitem, testDateRangeObject);
+        ParserContext context = ObjectConverter.copyFromRecord(dataSetitem, testDateRangeObject, false);
         Assert.assertTrue(testDateRangeObject != null);
         Assert.assertTrue(testDateRangeObject.dateTime != null);
     }

--- a/test/PrimaryKeyTest.java
+++ b/test/PrimaryKeyTest.java
@@ -1,0 +1,57 @@
+import org.junit.Assert;
+import org.junit.Test;
+import sdk.annotations.Attribute;
+import sdk.annotations.PrimaryKey;
+import sdk.converter.ObjectConverter;
+import sdk.data.DataSetItem;
+
+public class PrimaryKeyTest {
+
+
+
+    @Test
+    public void testPrimaryKeyNotOverwrite(){
+        DemoObject demoObject = new DemoObject();
+        DataSetItem dataSetItem = new DataSetItem(ObjectConverter.generateConfigurationAttributes(DemoObject.class));
+        String value1 = "testValue1";
+        String value2 = "testValue2";
+        String primaryKey = "testOverWrite";
+        dataSetItem.setPrimaryKey(primaryKey);
+        dataSetItem.setString(value1, 0);
+        dataSetItem.setString(value2, 1);
+
+        ObjectConverter.copyFromRecord(dataSetItem, demoObject, true);
+        Assert.assertTrue(!demoObject.testPrimaryKey.equals(primaryKey));
+        Assert.assertTrue(demoObject.testPrimaryKey.equals(value1));
+    }
+
+
+    @Test
+    public void testPrimaryKeyOverwrite(){
+        DemoObject demoObject = new DemoObject();
+        DataSetItem dataSetItem = new DataSetItem(ObjectConverter.generateConfigurationAttributes(DemoObject.class));
+        String value1 = "testValue1";
+        String value2 = "testValue2";
+        String primaryKey = "testOverWrite";
+        dataSetItem.setPrimaryKey(primaryKey);
+        dataSetItem.setString(value1, 0);
+        dataSetItem.setString(value2, 1);
+
+        ObjectConverter.copyFromRecord(dataSetItem, demoObject, false);
+        Assert.assertTrue(demoObject.testPrimaryKey.equals(primaryKey));
+        Assert.assertTrue(!demoObject.testPrimaryKey.equals(value1));
+    }
+
+
+    public class DemoObject {
+        @Attribute(index = 0)
+        @PrimaryKey
+        public String testPrimaryKey;
+
+        @Attribute(index = 1)
+        public String testSecondValue;
+
+        public DemoObject() {
+        }
+    }
+}

--- a/test/TimeIntervalTest.java
+++ b/test/TimeIntervalTest.java
@@ -58,7 +58,7 @@ public class TimeIntervalTest {
         dataSetItem.setTimeInterval(100L, 3);
 
         TimeIntTest timeIntTest = new TimeIntTest();
-        ObjectConverter.copyFromRecord(dataSetItem, timeIntTest);
+        ObjectConverter.copyFromRecord(dataSetItem, timeIntTest, false);
         Assert.assertTrue(dataSetItem.getInt(0) == timeIntTest.id);
         Assert.assertTrue(dataSetItem.getDouble(1) == timeIntTest.value);
         Assert.assertTrue(dataSetItem.getString(2).equals(timeIntTest.name));


### PR DESCRIPTION
There was an issue on Search forms and Primary keys. 
In the past, the primary would overwrite the value copied from the object with an empty value if the form was a search form because it had no primary key set. 
Now we are checking if it is a search form and will overwrite the primary key only if it is not a search form.  