### PR TITLE
successive searches bug fix

### DIFF
--- a/app/sdk/converter/ObjectConverter.java
+++ b/app/sdk/converter/ObjectConverter.java
@@ -124,10 +124,7 @@ public class ObjectConverter extends ConfigurationManager {
 
 
     private static ParserContext getParserContext() {
-        if (parserContext == null) {
-            parserContext = new ParserContext();
-        }
-        return parserContext;
+        return new ParserContext();
     }
 
 


### PR DESCRIPTION
The ParserContext was getting carried over between searches. This meant that the date ranges from previous searches (if from different fields) would be applied to the next search as well, despite what was in the request payload.
Example: searching for a customer part order->
1) search on 'order date'
2) do a new search on 'shipped date'
the 'shipped date' search would also include the 'order date' range field in the parser context.