### PR TITLE
Copying all object attributes over then copy the attachment specific …

### DIFF
--- a/app/sdk/utils/RecordUtils.java
+++ b/app/sdk/utils/RecordUtils.java
@@ -33,6 +33,7 @@ public class RecordUtils {
         Collection<ApptreeAttachment> newAttachments = new ArrayList<>();
         for (DataSetItemAttachment attachment : attachments) {
             ApptreeAttachment newAttachment = (ApptreeAttachment) proxy.getType().newInstance();
+            ObjectConverter.copyFromRecord(attachment, newAttachment, false);
             ObjectConverter.copyFromAttachment(attachment, newAttachment);
             newAttachments.add(newAttachment);
         }


### PR DESCRIPTION
When copying form AttachmentDataSetItem to attachments we were copying all attachment specific fields but not the object fields, like the primary key. 

This fix first copies all object fields like any other object, then it calls the attachment specific functions.