### PR TITLE
Returning no value instead of throwing an exception when converting list items

### DIFF
--- a/app/sdk/list/ListItem.java
+++ b/app/sdk/list/ListItem.java
@@ -63,7 +63,8 @@ public class ListItem implements Record {
         ListItemAttribute attribute = null;
 
         if (index > 79 || index < 0)
-            Logger.warn("The index you specified (" + index + ") is beyond the allowed number of attributes ( 0 - 79 )");
+            Logger.warn("The index you specified (" + index +
+                        ") is beyond the allowed number of attributes ( 0 - 79 )");
         if (value != null) {
             if (value instanceof String) {
                 attribute = new ListItemAttribute((String) value);
@@ -74,7 +75,8 @@ public class ListItem implements Record {
             } else if (value instanceof Location) {
                 attribute = new ListItemAttribute((Location) value);
             } else if (value instanceof DateTime) {
-                Logger.warn("setAttributeForIndex(Object value, int index) with a value type of DateTime assumes that the date contains a time component. Use setDateAttributeAtIndex(DateTime date, boolean time) to be more explicit.");
+                Logger.warn(
+                    "setAttributeForIndex(Object value, int index) with a value type of DateTime assumes that the date contains a time component. Use setDateAttributeAtIndex(DateTime date, boolean time) to be more explicit.");
                 attribute = new ListItemAttribute((DateTime) value, true);
             } else if (value instanceof DateRange) {
                 attribute = new ListItemAttribute((DateRange) value);
@@ -89,7 +91,8 @@ public class ListItem implements Record {
             } else if (value instanceof Boolean) {
                 attribute = new ListItemAttribute((Boolean) value);
             } else {
-                throw new UnsupportedOperationException("List does not support a value of type " + value.getClass().getCanonicalName());
+                throw new UnsupportedOperationException(
+                    "List does not support a value of type " + value.getClass().getCanonicalName());
             }
         }
         itemAttributes.put(index, attribute);
@@ -105,7 +108,8 @@ public class ListItem implements Record {
      */
     public void setDateAttributeForIndex(DateTime date, boolean time, int index) {
         if (index > 79 || index < 0)
-            Logger.warn("The index you specified (" + index + ") is beyond the allowed number of attributes ( 0 - 79 )");
+            Logger.warn("The index you specified (" + index +
+                        ") is beyond the allowed number of attributes ( 0 - 79 )");
         ListItemAttribute attribute = null;
         if (date != null) {
             attribute = new ListItemAttribute(date, time);
@@ -238,7 +242,8 @@ public class ListItem implements Record {
     @Override
     public void setDate(DateTime value, int index) {
         if (index > 79 || index < 0)
-            Logger.warn("The index you specified (" + index + ") is beyond the allowed number of attributes ( 0 - 79 )");
+            Logger.warn("The index you specified (" + index +
+                        ") is beyond the allowed number of attributes ( 0 - 79 )");
         ListItemAttribute attribute = null;
         if (value != null) {
             attribute = new ListItemAttribute(value, false);
@@ -383,7 +388,8 @@ public class ListItem implements Record {
     @Override
     public void setDateTime(DateTime value, int index) {
         if (index > 79 || index < 0)
-            Logger.warn("The index you specified (" + index + ") is beyond the allowed number of attributes ( 0 - 79 )");
+            Logger.warn("The index you specified (" + index +
+                        ") is beyond the allowed number of attributes ( 0 - 79 )");
         ListItemAttribute attribute = null;
         if (value != null) {
             attribute = new ListItemAttribute(value, true);
@@ -458,32 +464,34 @@ public class ListItem implements Record {
 
     @Override
     public void setListItem(ListItem value, int index) {
-        throw new RuntimeException("Can not set list item on a list item");
+        return;
     }
 
     @Override
     public ListItem getListItem(int index) {
-        throw new RuntimeException("Can not get list item from a list item");
+        // instead of causing an error I am just to not return a value
+        // when converting, the calling function is prepared for null values
+        return null;
     }
 
     @Override
     public Optional<ListItem> getOptionalListItem(int index) {
-        throw new RuntimeException("Can not get list item from a list item");
+        return Optional.empty();
     }
 
     @Override
     public DataSetItem getDataSetItem(int index) {
-        throw new RuntimeException("Unable to get Data Set Item from list item");
+        return null;
     }
 
     @Override
     public List<DataSetItem> getDataSetItems(int index) {
-        throw new RuntimeException("Unable to get Data Set Item from list item");
+        return null;
     }
 
     @Override
     public DataSetItem addNewDataSetItem(int index) {
-        throw new RuntimeException("Unable to get Data Set Item from Data Set Item");
+        return null;
     }
 
     @Override
@@ -614,7 +622,9 @@ public class ListItem implements Record {
     static class ListItemSerializer extends JsonSerializer<ListItem> {
 
         @Override
-        public void serialize(ListItem value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        public void serialize(ListItem value, JsonGenerator gen,
+                              SerializerProvider serializers) throws IOException,
+                                                                     JsonProcessingException {
             gen.writeStartObject();
             gen.writeStringField("id", value.id);
             gen.writeStringField("value", value.value);
@@ -650,9 +660,12 @@ public class ListItem implements Record {
         if (Double.compare(listItem.longitude, longitude) != 0) return false;
         if (maxAttributeIndex != listItem.maxAttributeIndex) return false;
         if (id != null ? !id.equals(listItem.id) : listItem.id != null) return false;
-        if (parentID != null ? !parentID.equals(listItem.parentID) : listItem.parentID != null) return false;
+        if (parentID != null ? !parentID.equals(listItem.parentID) : listItem.parentID != null)
+            return false;
         if (value != null ? !value.equals(listItem.value) : listItem.value != null) return false;
-        return attributeConfiguration != null ? attributeConfiguration.equals(listItem.attributeConfiguration) : listItem.attributeConfiguration == null;
+        return attributeConfiguration != null ?
+               attributeConfiguration.equals(listItem.attributeConfiguration) :
+               listItem.attributeConfiguration == null;
     }
 
     @Override
@@ -668,7 +681,8 @@ public class ListItem implements Record {
         temp = Double.doubleToLongBits(longitude);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         result = 31 * result + maxAttributeIndex;
-        result = 31 * result + (attributeConfiguration != null ? attributeConfiguration.hashCode() : 0);
+        result =
+            31 * result + (attributeConfiguration != null ? attributeConfiguration.hashCode() : 0);
         return result;
     }
 }


### PR DESCRIPTION
Updating the list item class to not throw an exception and cause a submission to fail is something tries to get another list item from it when converting. 

This issue is caused when the annotation processor thinks you have a list item that then has a field that the annotation processor thinks is a list item. 
e.g. 

```
class WorkOrder{
  @Attribute(index = 0)
  private Property property; // A.P. thinks this is a ListItem
}

class Property {
  @Attribute(index = 0)
  private Space space; // A.P. thinks this is a list item
  
  @Attribute(index = 0, excludeFromListItem = true) // how we handle typically that
  private Asset asset; // A.P. thinks this is a list item but excludes
  
}
```
This will cause the annotation processor to ignore a ListItem -> ListItem instead of throwing an exception. 