### PR TITLE
Fix setter method lookup

### DIFF
--- a/app/sdk/converter/TypeManager.java
+++ b/app/sdk/converter/TypeManager.java
@@ -355,7 +355,7 @@ public class TypeManager {
      * @return
      */
     protected static <T> boolean fieldHasSetter(AttributeProxy proxy, T object) {
-        Map<String, Method> tempMap = getMethodMap().get(object.getClass().getName().toLowerCase());
+        Map<String, Method> tempMap = getMethodMap().get(object.getClass().getName());
         if (tempMap == null) return false;
         return (tempMap.containsKey(setterMethodName(proxy)));
     }


### PR DESCRIPTION
@SamOrozco @alexisandreason this was the only place that was using toLowercase() on the class name. When the map is set and for all other lookups it just uses the class name.

This fixes [APPTREE-8759 Adding Tracking to Part Order in App Fails](https://apptree.myjetbrains.com/youtrack/issue/APPTREE-8759).

The `DistShipmentCreate` relies on the setter being called to extract the string from a list item.