### PR TITLE
Adding flag for ingore an attribute or relationship when writing a dataSetItem response and when reading from a data set item

### DIFF
--- a/app/sdk/annotations/Attribute.java
+++ b/app/sdk/annotations/Attribute.java
@@ -6,6 +6,7 @@ import sdk.models.AttributeType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Supplier;
 
 /**
  * Created by Orozco on 7/19/17.
@@ -13,16 +14,35 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Attribute {
     int index();
+
     String name() default "";
+
     AttributeType dataType() default AttributeType.None;
+
     Class relationshipClass() default Class.class;
+
     boolean excludeFromList() default false;
+
     boolean useGetterAndSetter() default true;
+
     boolean canCreate() default true;
+
     boolean canCreateAndRequired() default false;
+
     boolean canUpdate() default true;
+
     boolean canUpdateAndRequired() default false;
+
     boolean canSearch() default true;
+
     boolean canSearchAndRequired() default false;
+
+    // ignore read ignores this attribute when reading
+    // from a data set to our model object
+    boolean ignoreRead() default false;
+
+    // ignore write ignore writing this attribute when writing our model
+    // object to a data set item
+    boolean ignoreWrite() default false;
 }
 

--- a/app/sdk/annotations/Relationship.java
+++ b/app/sdk/annotations/Relationship.java
@@ -6,14 +6,32 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Relationship {
     String value() default "";
+
     boolean eager() default true;
+
     int index();
+
     String name() default "";
+
     boolean useGetterAndSetter() default true;
+
     boolean canCreate() default true;
+
     boolean canCreateAndRequired() default false;
+
     boolean canUpdate() default true;
+
     boolean canUpdateAndRequired() default false;
+
     boolean canSearch() default true;
+
     boolean canSearchAndRequired() default false;
+
+    // ignore read ignores this relationship when reading
+    // from a data set to our model object
+    boolean ignoreRead() default false;
+
+    // ignore write ignore writing this relationship when writing our model
+    // object to a data set item
+    boolean ignoreWrite() default false;
 }

--- a/app/sdk/converter/AttributeProxy.java
+++ b/app/sdk/converter/AttributeProxy.java
@@ -73,6 +73,16 @@ public class AttributeProxy {
         return !Null(attribute);
     }
 
+    public boolean ignoreWrite() {
+        return (isAttribute() && attribute.ignoreWrite()) ||
+               (isRelationship() && relationship.ignoreWrite());
+    }
+
+    public boolean ignoreRead() {
+        return (isAttribute() && attribute.ignoreRead()) ||
+               (isRelationship() && relationship.ignoreRead());
+    }
+
     public boolean isPrimaryKey() {
         return !Null(primaryKey);
     }

--- a/app/sdk/converter/ObjectConverter.java
+++ b/app/sdk/converter/ObjectConverter.java
@@ -247,6 +247,7 @@ public class ObjectConverter extends ConfigurationManager {
                                                                      UnsupportedAttributeException,
                                                                      UnableToWriteException,
                                                                      InvocationTargetException {
+        if (proxy.ignoreRead()) return;
         if (!proxy.isAttribute() && !proxy.isRelationship() && !proxy.isStatus()) return;
         if (record.isListItem() && proxy.excludeFromList()) return;
 
@@ -277,7 +278,7 @@ public class ObjectConverter extends ConfigurationManager {
                                           T source) throws UnsupportedAttributeException,
                                                            IllegalAccessException,
                                                            InvocationTargetException {
-
+        if (attributeProxy.ignoreWrite()) return;
         if (record.isListItem() && attributeProxy.excludeFromList()) return;
 
         boolean primaryKey = attributeProxy.isPrimaryKey();


### PR DESCRIPTION
I ran into an issue in the Taylor connector reading from an enum as a list item. I really only need the list item on my model to provide a list for the user to select. I just auto-fill a string property on the form.  

The `ignoreWrite` flag tells the annotation processor not to write that attribute or relation in the dataset item response. 

The `ignoreRead` flag tells the annotation processor not to read an attribute or relationship from the dataset item when copying from dataset item into the model object. 